### PR TITLE
Be able to change how many players it shows when using /timechecker top in the config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.github.alfonsoLeandro</groupId>
             <artifactId>MPUtils</artifactId>
-            <version>1.6.0</version>
+            <version>1.8.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,7 +12,11 @@ config:
     self session check: '&fYou have been playing &c%time% &fon this server for this session.'
     other session check: '&c%player% &fhas been playing &c%time% &fon this server for their last session.'
     calculating: '&aCalculating...'
-    top 10: '&6&lTOP 10 players by playtime:'
+
+    top list: '&6&lTOP %amounttop% players by platime:'
+    #Sets how big is the top number. WARNING: Big numbers might take a long time
+    amount top: 10
+
     top player: '%pos%) &f%player%: &c%time%&f.'
     and: 'and'
     week: 'week'


### PR DESCRIPTION
Updated dependency MPUtils from 1.6.0 to 1.8.1 and added the possibility to change how many players it shows when using the command top.